### PR TITLE
remove `libraries` from properties due to new defaults

### DIFF
--- a/google-streetview-pano.html
+++ b/google-streetview-pano.html
@@ -14,11 +14,6 @@ Element for generating a Google Maps Street View Panorama.
       disable-default-ui>
     </google-streetview-pano>
 
-**Note**: To use this element on the same page as `<google-map>` (or other google-map-* components),
-be sure to include the `libraries="places"` attribute on those elements:
-
-   <google-map libraries="places" ...></google-map>
-
 There are tons of great panoramas on the [Google Maps | Views page](https://www.google.com/maps/views/home?gl=us)
 
 To grab a panorama, look at its url in the address bar. For example:
@@ -51,7 +46,6 @@ You can also use the position attribute and set it to a position with a computed
   </style>
   <template>
     <google-maps-api api-key="{{apiKey}}" version="{{version}}"
-                     libraries="{{libraries}}"
                      client-id="{{clientId}}"
                      language="{{language}}"
                      client
@@ -89,17 +83,6 @@ You can also use the position attribute and set it to a position with a computed
        *
        */
       language: String,
-
-      /**
-       * A comma separated list (e.g. "places,geometry") of libraries to load
-       * with this map. Defaults to "places". For more information see
-       * https://developers.google.com/maps/documentation/javascript/libraries.
-       *
-       */
-      libraries: {
-        type: String,
-        value: "places"
-      },
 
       /**
        * Version of the Google Maps API to use.


### PR DESCRIPTION
In anticipation of landing https://github.com/GoogleWebComponents/google-apis/pull/58, remove `libraries` as a property. All existing code will continue to work as setting `libraries` will now just be a no-op.

For compatibility, we'll probably have to update the `google-apis` requirement in `bower.json`. When that lands I can add that to this commit or someone can rev separately.